### PR TITLE
[BOJ] 1931_회의실배정 / 실버1 / 45분 / O

### DIFF
--- a/week1/BOJ_1931/회의실배정_한의정.java
+++ b/week1/BOJ_1931/회의실배정_한의정.java
@@ -1,0 +1,55 @@
+import java.util.*;
+import java.io.*;
+
+class Meeting implements Comparable<Meeting> {
+    int s, e;
+
+    public Meeting(int s, int e) {
+        this.s = s;
+        this.e = e;
+    }
+
+    // 종료 시간 순 오름차순 정렬
+    @Override
+    public int compareTo(Meeting mm) {
+        // 종료시간이 다르다면, 종료 시간 순 오름차순 정렬
+        if(this.e != mm.e)
+            return this.e - mm.e;
+
+        // 종료시간이 같다면, 시작 시간 순 오름차순 정렬
+        return this.s - mm.s;
+    }
+}
+
+public class 회의실배정_한의정 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+        Meeting[] m = new Meeting[N];
+
+        for(int i = 0 ; i < N ; i++) {
+            st = new StringTokenizer(br.readLine(), " ");
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+
+            m[i] = new Meeting(s, e);
+        }
+        Arrays.sort(m);
+
+        int tmpS = m[0].s;
+        int tmpE = m[0].e;
+        int cnt = 1;    // 첫 번째 값
+
+        for(int i = 1 ; i < m.length ; i++) {
+            if(tmpE <= m[i].s) {
+                tmpS = m[i].s;
+                tmpE = m[i].e;
+                cnt++;
+            }
+        }
+
+        System.out.println(cnt);
+    }
+}


### PR DESCRIPTION
### 📖 문제
- 백준 1931 - 회의실 배정


### 💡 풀이 방식
> 시간 복잡도 : O(N)

1. 회의 **종료 시간 순** 오름차순 정렬한다.
2. **이전 회의 종료 시간 <= 현재 회의 시작 시간** 인 경우, 기준이 되는 종료 시간을 현재 회의의 종료 시간으로 변경하고, 정답을 +1한다.

### 🤔 어려웠던 점
정렬 기준을 찾는 데 생각보다 시간이 오래 걸렸다.
<br/>

### ❗ 새로 알게된 내용
없음