### PR TITLE
[BOJ] 2800_괄호제거 / 골드5 / 60분 / X

### DIFF
--- a/week2/BOJ_2800/괄호제거_한의정.java
+++ b/week2/BOJ_2800/괄호제거_한의정.java
@@ -1,2 +1,79 @@
+import java.util.*;
+import java.io.*;
+
 public class 괄호제거_한의정 {
+    static char[] ch;
+
+    static List<Pair> list = new ArrayList<>();
+    static Set<String> result = new TreeSet<>();
+    static boolean[] check; // 쌍 맺는 괄호 지울지 판단하는 배열
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        ch = br.readLine().toCharArray();
+
+        // 1. 괄호 쌍 구하기
+        Stack<Integer> stack = new Stack<>();
+
+        for(int i = 0 ; i < ch.length ; i++) {
+            if(ch[i] == '(') {
+                stack.push(i);
+            }
+            else if(ch[i] == ')') {
+                list.add(new Pair(stack.pop(), i));
+            }
+        }
+
+        // 2. 괄호 존재여부 모든 조합 구하기
+        check = new boolean[ch.length];
+        comb(0);
+
+        // 출력하기
+        Iterator<String> iter = result.iterator();  // set을 iterator 안에 담기
+        while(iter.hasNext()) {
+            System.out.println(iter.next());
+        }
+    }
+
+    private static void comb(int depth) {
+        if(depth == list.size()) {
+            boolean b = false;
+
+            StringBuilder sb = new StringBuilder();
+            for(int i = 0 ; i < ch.length ; i++) {
+                if(!check[i]) {
+                    sb.append(ch[i]);
+                }
+                else {
+                    b = true;
+                }
+            }
+
+            if(b) {
+                result.add(sb.toString());
+            }
+            return;
+        }
+
+        // 현재 괄호 제거 안 함
+        comb(depth + 1);
+
+        // 현재 괄호 제거
+        Pair now = list.get(depth);
+        check[now.start] = true;
+        check[now.end] = true;
+        comb(depth + 1);
+        check[now.start] = false;
+        check[now.end] = false;
+    }
+}
+
+class Pair {
+    int start, end;
+
+    public Pair(int start, int end) {
+        this.start = start;
+        this.end = end;
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 2800 - 괄호 제거
### 💡 풀이 방식
> 시간 복잡도 : O(N)

- 자료구조
   - (여는 괄호 위치, 닫는 괄호 위치) 저장 객체
   - 괄호 위치 객체 저장 리스트
   - 괄호 제거해서 나오는 식 저장할 TreeSet
   - 괄호 지울지 말지 판단용 boolean 배열

1. 여는 괄호인 경우, 스택에 시작 위치 인덱스를 넣는다.
2. 닫는 괄호인 경우, (스택의 여는 괄호 인덱스, 현재 인덱스)를 넣는다.
3. 백트래킹을 통해 괄호가 존재하는 모든 조합을 구한다.

### 🤔 어려웠던 점
- 스택에 괄호 넣을 생각만 했지, 위치 인덱스를 넣을 생각은 하지 못 했다...
- 백트래킹 쓸 생각은 했는데 어떻게 결과를 저장하고 출력할지를 잘 생각하지 못 했다.
### ❗ 새로 알게 된 내용
`TreeSet` : 자동으로 중복 제거 & 사전 순 정렬