### PR TITLE
[BOJ] 20546_기적의매매법 / 실버5 / 70분 / O

### DIFF
--- a/week3/BOJ_20546/기적의매매법_한의정.java
+++ b/week3/BOJ_20546/기적의매매법_한의정.java
@@ -1,2 +1,66 @@
+import java.util.*;
+import java.io.*;
+
 public class 기적의매매법_한의정 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+        int[] arr = new int[14];
+        st = new StringTokenizer(br.readLine(), " ");
+        for(int i = 0 ; i < 14 ; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // [준현]
+        int money1 = N; // 남은 현금
+        int stock1 = 0; // 보유 주식 수
+
+        // 최대한 많이 사 -> 그리디
+        for(int i = 0 ; i < arr.length ; i++) {
+            if(money1 / arr[i] > 0) {
+                int cnt = money1 / arr[i];
+                stock1 += cnt;
+                money1 -= arr[i] * cnt;
+            }
+        }
+
+
+        // [성민]
+        int money2 = N; // 남은 현금
+        int stock2 = 0; // 보유 주식 수
+
+        for(int i = 0 ; i < arr.length - 3 ; i++) {
+            // 3일 연속 가격이 전일 대비 상승한다면, 다 팔아 (전량 매도)
+            if((arr[i] < arr[i + 1]) && (arr[i + 1] < arr[i + 2])) {
+                if(stock2 == 0) continue;
+
+                money2 += arr[i + 3] * stock2;
+                stock2 = 0;
+            }
+            // 3일 연속 가격이 전일 대비 하락한다면, 즉시 다 사 (전량 매수)
+            else if((arr[i] > arr[i + 1]) && (arr[i + 1] > arr[i + 2])) {
+                if(money2 / arr[i + 3] > 0) {
+                    int cnt = money2 / arr[i + 3];
+                    stock2 += cnt;
+                    money2 -= arr[i + 3] * cnt;
+                }
+            }
+        }
+
+        // 둘 중 누가 더 높은 수익률 내는지 (보유 현금 + 1.14 주가 * 주식 수)
+        int profit1 = money1 + arr[arr.length - 1] * stock1;
+        int profit2 = money2 + arr[arr.length - 1] * stock2;
+
+        if(profit1 > profit2) {
+            System.out.println("BNP");
+        }
+        else if(profit1 < profit2) {
+            System.out.println("TIMING");
+        }
+        else {
+            System.out.println("SAMESAME");
+        }
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 20546 -  [🐜 기적의 매매법 🐜](https://www.acmicpc.net/problem/20546)
### 💡 풀이 방식
> 시간 복잡도 : O(N)

1. [준현] **그리디**를 활용해 남은 현금과 보유 주식 수를 구한다.
2. [성민]
   - 3일 연속 가격이 전일 대비 상승 시, 그 다음 날에 다 판다. (전량 매수)
   -  &nbsp;  &nbsp;  &nbsp;  &nbsp;  &nbsp;  &nbsp;  &nbsp;  &nbsp; &nbsp;  &nbsp;  &nbsp;  &nbsp;  &nbsp; "&nbsp;  &nbsp;  &nbsp;  &nbsp;  &nbsp;  &nbsp;  &nbsp; &nbsp; 하락 시, 그 다음 날에 다 산다. (전량 매도)
3. 둘 중 누가 더 높은 수익률을 내는지 계산한다. <br/>→ `최종 보유 현금 + 1.14 주가 * 최종 보유 주식 수`
### 🤔 어려웠던 점
- 매도-매수 단어가 헷갈렸다,,
- 성민이가 `3일 연속 가격이 전일 대비 하락한다면, "즉시" 전량 매수`라고 해서 셋째 날에 바로 전량 매수를 했는데, 이러니까 틀렸다. 그래서 그 다음 날인 **넷째 날 거래**했더니 해결되었다.
- 집중을 빠짝했다면 더 빨리 풀 수 있었을 것 같다,,
### ❗ 새로 알게 된 내용
X
