### PR TITLE
[BOJ] 20207_달력 / 골드5 / 90분 / X

### DIFF
--- a/week3/BOJ_20207/달력_한의정.java
+++ b/week3/BOJ_20207/달력_한의정.java
@@ -1,2 +1,46 @@
+import java.util.*;
+import java.io.*;
+
 public class 달력_한의정 {
+    static int DAY_OF_YEAR = 365;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+        int[] cntArr = new int[DAY_OF_YEAR + 1];
+
+        while(N --> 0) {
+            st = new StringTokenizer(br.readLine(), " ");
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+
+            // 구간 색칠하기
+            for(int i = from ; i <= to ; i++) {
+                cntArr[i]++;
+            }
+        }
+
+        int total = 0;
+        int w = 0;
+        int maxH = 0;
+
+        for(int i = 0 ; i <= DAY_OF_YEAR ; i++) {
+            if(cntArr[i] != 0) {
+                w++;
+                maxH = Math.max(maxH, cntArr[i]);
+            }
+            else {
+                total += w * maxH;
+
+                // 너비와 최대 높이 초기화
+                w = 0;
+                maxH = 0;
+            }
+        }
+
+        total += w * maxH;  // 마지막꺼
+        System.out.println(total);
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 20207 - [달력](https://www.acmicpc.net/problem/20207)
### 💡 풀이 방식
> 시간 복잡도 : O(N)

1. 구간을 입력받고, 해당 시작점부터 끝점까지 구간을 색칠한다. <br/> → **_카운트 배열 사용_**
2. 카운트 배열을 돌면서 해당 칸의 값이 0이 아니라면, 너비 + 1하고 높이는 최대 높이와 비교해 더 큰 값으로 갱신한다. / 해당 칸의 값이 0이라면, 여태까지 구한 너비와 최대 높이를 구해 넓이 값에 누적해 저장하고, 너비와 최대 높이는 0으로 초기화한다.
3. 마지막 구간 처리를 위해 마지막에 넓이들의 합에 `너비 * 최대 높이` 구한 값을 더해줘야 한다!!

### 🤔 어려웠던 점
- 입력 값 정렬이나 이럴 필요 없이 배열에 값을 누적해 저장하기만 하면 된다는 걸 생각해내는데 오래 걸렸다.
- 마지막 범위 처리를 놓쳐서 틀렸었다..

### ❗ 새로 알게 된 내용
X
