### PR TITLE
[BOJ] 1325_효율적인 해킹 / 실버1 / 50분 / X

### DIFF
--- a/week5/BOJ_1325/효율적인해킹_한의정.java
+++ b/week5/BOJ_1325/효율적인해킹_한의정.java
@@ -1,2 +1,68 @@
+import java.util.*;
+import java.io.*;
+
 public class 효율적인해킹_한의정 {
+    static int N, M;
+    static List<Integer>[] A;   // 인접 리스트 배열
+    static boolean[] visited;   // 방문 배열
+
+    static int maxDepth = -1;   // 최대 해킹 가능한 컴퓨터 수
+    static int[] cntArr;        // 노드 별 해킹 컴퓨터 수 저장 배열
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        A = new ArrayList[N + 1];
+        for(int i = 1 ; i <= N ; i++)   A[i] = new ArrayList<>();
+
+        while(M --> 0) {
+            st = new StringTokenizer(br.readLine(), " ");
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            A[a].add(b);
+        }
+
+        cntArr = new int[N + 1];
+
+        for(int i = 1 ; i <= N ; i++) {
+            visited = new boolean[N + 1];   // 매번 초기화해야 함 !
+            bfs(i);
+        }
+
+        for(int i = 1 ; i <= N ; i++) {
+            if(cntArr[i] > maxDepth) {
+                maxDepth = cntArr[i];
+            }
+        }
+
+        for(int i = 1 ; i <= N ; i++) {
+            if(maxDepth == cntArr[i]) {
+                System.out.print(i + " ");
+            }
+        }
+    }
+
+    private static void bfs(int num) {
+        Queue<Integer> q = new ArrayDeque<>();
+        q.add(num);
+
+        visited[num] = true;
+
+        while(!q.isEmpty()) {
+            int now = q.poll();
+
+            for(int next : A[now]) {
+                if(!visited[next]) {
+                    q.add(next);
+                    visited[next] = true;
+                    cntArr[next]++; // 해킹 가능한 컴퓨터 수 + 1
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 1325 - [효율적인 해킹](https://www.acmicpc.net/problem/1325)
<br/>

### 💡 풀이 방식
> BFS

사용 자료구조
> - 인접 리스트 배열
> - boolean형 방문 배열
> - int형 노드 별 해킹 가능한 컴퓨터 수 저장 배열
> - 최대 해킹 가능한 컴퓨터 수를 저장하는 int형 변수

1. 인접 리스트에 값을 입력 받는다. → `A[a].add(b)`
2. 1번부터 N번 노드까지 방문 배열을 매번 초기화하고 BFS를 수행한다.
    - BFS 수행 시, 각 점과 연결된 점들을 방문하면서, **그와 연결된 노드들의 카운트를 올리고**, 연결된 노드를 방문처리하고, 큐에 저장한다.



<br/>

### 🤔 어려웠던 점
- 시간 초과가 자꾸 떠서 시간을 많이 잡아먹었다... 😭 
- Queue를 선언할 때 `LinkedList`로 했던 걸 `ArrayDeque`로 바꿨더니 다행히 정답이 되었다...
- 모든 점마다 매번 방문 배열을 새로 초기화하는 부분도 놓쳤었다. 이러는 이유는 아래와 같다고 한다.

![image](https://github.com/bono039/algorithm-study/assets/67899934/97b003c5-f9b6-4842-af80-8a6fba499386)


- 노드 별 해킹 가능한 컴퓨터 수는 참고로 아래와 같다..
![image](https://github.com/bono039/algorithm-study/assets/67899934/67dda7df-6da7-431d-b575-72e63cf7770d)


<br/>

### ❗ 새로 알게 된 내용
X
