### PR TITLE
[BOJ] 11725_트리의부모찾기 / 실버2 / 40분 / X

### DIFF
--- a/week5/BOJ_11725/트리의부모찾기_강한주.java
+++ b/week5/BOJ_11725/트리의부모찾기_강한주.java
@@ -1,0 +1,64 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    static int[] parent;
+    static boolean[] visited;
+    static ArrayList<ArrayList<Integer>> edges = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        visited = new boolean[n + 1];
+        parent = new int[n + 1];
+
+        for (int i = 0; i < n + 1; i++) {//ArrayList 생성
+            edges.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int node1 = Integer.parseInt(st.nextToken());
+            int node2 = Integer.parseInt(st.nextToken());
+            edges.get(node1).add(node2); //node1과 node2가 연결되어있다고 표시
+            edges.get(node2).add(node1); //서로 연결
+        }
+
+        dfs(1);
+
+        for (int i = 2; i <= n; i++) {//2번부터 N번 노드까지의 부모 출력
+            System.out.println(parent[i]);
+        }
+    }
+
+    static void dfs(int node) {
+        visited[node] = true;
+
+        for (int v : edges.get(node)) {//node랑 연결되어있는 번호들을 탐색한다
+            if (!visited[v]) {//만약 번호v를 방문하지 않았다면 dfs
+                parent[v] = node;
+                dfs(v);
+            }
+        }
+    }
+//잘못쓴코드
+//    for(int i = 0;i<n-1;i++){
+//        if (visited[node1] && visited[node2]) {
+//            continue;
+//        } else if (visited[node1]) {//node1번을 방문했나? 방문이 되어있으면 node2는 당연히 node1의 자식이 된다
+//            visited[node2] = true; //node2 방문처리
+//            parent[node2] = node1;//node1의 자식은 node2
+//        } else if (visited[node2]) {//node1번을 방문한적이없고 node2번을 방문한적이 있으면 node2번이 node1번의 부모가 된다
+//            visited[node1] = true;
+//            parent[node1] = node2;
+//        } else {//둘다 방문한 노드가 아닐 경우
+//            visited[node1] = true;
+//            parent[node1] = node2;
+//        }
+//    }
+
+}


### PR DESCRIPTION
### 📖 문제
- 백준 11725-트리의 부모찾기
<br/>

### 💡 풀이 방식

1. `ArrayList<ArrayList<Integer>> edges` 를 통해 두 노드가 연결된 것을 표시했다
2. DFS 알고리즘을 활용하여 `edges.get(node)` node에 연결된 다른 노드들의 번호 v를 구해
3. v를 방문하지 않았다면 `parent[v] = node`로 부모 표시를 하고 v와 연결된 다른 노드번호가 있는지 구하기 위해 dfs(v)를 사용했다 (재귀)


<br/>

### 🤔 어려웠던 점

처음엔 parent와 visited 두 배열만 사용해서 테스트케이스를 통과했다. 
내가 처음에 푼 방법은
1. 일단 처음 `visited[1] = true`; 로 원소1은 루트로 방문한걸로 체크했다
2. 다음에 node1,node2를 입력받으며 "둘 중 하나의 노드에 방문했다면 (`visited[node?] = true`), 방문하지 않은 노드는 방문한 노드의 자식이 된다(`parent[방문하지않은노드] = 방문한노드`) , 
`visited[방문하지않은노드] = true`이런식으로 풀었다.
4. 이렇게 풀면 테스트 케이스는 통과하지만 반례가 있었다. 바로 둘 다 방문하지 않은 노드가 주어질때이다( 예: 3 , 2 3, 1 2)
5. 이럴경우 어떤 노드를 부모로 둬야하는지 혼선이 생기므로 내 풀이는 틀리게 된다

반례를 알고 다시 풀라했으나 남은시간이 얼마 없어 다른 사람의 풀이를 보았다. 
`ArrayList<ArrayList<Integer>> edges` 자료구조를 활용해 노드의 연결을 표시하였고
DFS 알고리즘을 사용해서 부모를 구했다. 


<br/>

### ❗ 새로 알게된 내용
`ArrayList<ArrayList<Integer>>` 로 노드에 연결된 다른노드를 표현할 수 있다 
