### PR TITLE
[BOJ] 2178_미로 탐색 / 실버1 / 20분 / X

### DIFF
--- a/week5/BOJ_2178/미로탐색_강아현.py
+++ b/week5/BOJ_2178/미로탐색_강아현.py
@@ -1,0 +1,25 @@
+from collections import deque
+
+N, M = map(int,input().split())
+graph = [list(map(int,input())) for _ in range(N)] # 미로
+
+def bfs(graph,N,M):
+    q = deque([[0,0,1]])
+    # 상하좌우 탐색
+    dx = [1,-1,0,0]
+    dy = [0,0,1,-1]
+    # 미로 시작 위치
+    graph[0][0] = 0
+    while q:
+        nx, ny, answer = q.popleft()
+        # 탈출
+        if nx == N-1 and ny == M-1:
+            return answer
+        # 현재 위치에서 상하좌우 탐색
+        for i in range(4):
+            x, y = nx+dx[i], ny+dy[i]
+            if 0 <= x < N and 0 <= y < M and graph[x][y] == 1:
+                q.append([x,y,answer+1])
+                graph[x][y] = 0
+answer = bfs(graph,N,M)
+print(answer)


### PR DESCRIPTION
### 📖 문제
- 백준 2178 - 미로 탐색
<br/>

### 💡 풀이 방식

> **BFS**
>
> 1. 처음 위치인 0, 0과 이동횟수인 1을 deque에 담는다.
> 2. 그래프에서 이동한 위치는 값을 0으로
> 3. 이동하면서 상하좌우를 탐색하고 그래프의 값이 1인 곳으로 이동하면 deque에 (x,y,이동횟수)를 추가한다.
> 4. deque가 빌 때까지 진행하며 꺼내진 값의 x, y가 도착위치면 이동횟수를 리턴한다.

<br/>

### 🤔 어려웠던 점
x

<br/>

### ❗ 새로 알게된 내용
x
