### PR TITLE
[PSG] 택배 배달과 수거하기 / 90분 / X

### DIFF
--- a/week5/PSG/택배배달과수거하기_강아현.py
+++ b/week5/PSG/택배배달과수거하기_강아현.py
@@ -1,0 +1,17 @@
+from itertools import zip_longest as zip
+
+def tolist(l):
+    n=[]
+    for i,d in enumerate(l):
+        for _ in range(d):
+            n.append(i+1)
+    return n
+
+def solution(cap, n, deliveries, pickups):
+    d=tolist(deliveries) # 집별로 배달할 택배 수만큼 리스트에 집 번호를 모두 나타낸다.
+    p=tolist(pickups) # 집별로 수거할 택배 수만큼 리스트에 집 번호를 모두 나타낸다.
+    d.reverse()
+    p.reverse()
+    d=d[::cap] # cap 수만큼씩 자른다.
+    p=p[::cap]
+    return 2*sum([max(x,y) for x,y in zip(d,p,fillvalue=0)])


### PR DESCRIPTION
### 📖 문제
- 프로그래머스 - 택배 배달과 수거하기
<br/>

### 💡 풀이 방식

1. 집별로 배달할 택배 수만큼 리스트에 집 번호를 모두 나타낸다.
2. 집별로 수거할 택배 수만큼 리스트에 집 번호를 모두 나타낸다.
3. 1,2에서 구한 리스트를 거꾸로 정렬한다.
4. 3에서 정렬한 리스트를 cap 수만큼 자른다.
5. 4에서 구한 리스트의 원소값을 비교하며 d와 p 중 더 큰 원소를 구하고 이들의 누적합을 구한다.
6. 5에서 구한 누적합에 2를 곱하여 정답값으로 리턴한다.

<br/>

### 🤔 어려웠던 점
문제에 접근하는 것부터가 어려웠다. 배달할 택배 혹은 수거할 택배가 하나 이상 있는 집들의 인덱스를 가지고 와서 뭔가를 해보려했지만 시간초과 문제를 해결하지 못했다. 이 풀이처럼 1번집에 배달할 택배 : 1개, 2번집에 배달할 택배 : 2개가 있을 때 리스트를 [1,2,2] 이런 식으로 전부 나열하는 방법은 생각하지 못했다.

<br/>

### ❗ 새로 알게된 내용
zip_longest는 zip을 할 때 리스트 중 길이가 가장 긴 리스트를 기준으로 묶는 것이다.
