### PR TITLE
[BOJ] 11053_가장 긴 증가하는 부분 수열 / 실버2 / 40분 / O

### DIFF
--- a/week7/BOJ_11053/가장긴증가하는부분수열_한의정.java
+++ b/week7/BOJ_11053/가장긴증가하는부분수열_한의정.java
@@ -1,2 +1,33 @@
+import java.util.*;
+import java.io.*;
+
 public class 가장긴증가하는부분수열_한의정 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+        int[] A = new int[N];
+
+        st = new StringTokenizer(br.readLine(), " ");
+        for(int i = 0 ; i < N ; i++) {
+            A[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] dp = new int[N];
+        Arrays.fill(dp, 1); // dp 배열의 모든 값 1로 초기화
+
+        int max = 1;    // 초기값 1 !!!
+
+        for(int i = 0 ; i < N ; i++) {      // i 범위 : 0 ~ N - 1
+            for(int j = 0 ; j < i ; j++) {  // j 범위 : 0 ~ i - 1
+                if(A[i] > A[j]) {
+                    dp[i] = Math.max(dp[i], dp[j] + 1);
+                    max = Math.max(max, dp[i]);
+                }
+            }
+        }
+
+        System.out.println(max);
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 11053 - [가장 긴 증가하는 부분 수열](https://www.acmicpc.net/problem/11053)
<br/>

### 💡 풀이 방식
> 시간 복잡도 : O(N^2)

1. 최장 증가하는 부분 수열 크기를 나타내는 dp 배열을 만들고, 배열 내 모든 값을 1로 초기화한다.
2. 완전탐색으로 원본 배열의 시작부터 끝까지 돌면서 고른 칸 기준 앞쪽 칸에서 현재 값보다 작은 값을 갖고 있다면, dp 배열의 현재 칸 값과 이 앞쪽 칸의 값 + 1 중 더 큰 값을 비교해 현재 칸 값으로 갱신하면 현재 위치까지 가장 긴 부분 수열 길이를 구할 수 있다.
```
int max = 1;	 // 1로 해야 함,,, 0으로 했다가 틀림,,,,
   
for(int i = 0 ; i < N ; i++) {
    for(int j = 0 ; j < i ; j++) {    // 현재 칸 기준 앞쪽 칸 탐색
        if(A[i] > A[j]) {    // 앞쪽 칸의 값이 현재 칸의 값보다 작다면
            dp[i] = Math.max(dp[i], dp[j] + 1);    // 현재 dp 배열의 값 vs 앞에서 나온 가장 긴 부분 수열의 길이 + 1 中 큰 값으로 갱신한다.
	    max = Math.max(max, dp[i]);
        }
    }
}
```

<br/>

### 🤔 어려웠던 점
- max의 초기값을 0으로 설정해 20분간 헤매다....

<br/>

### ❗ 새로 알게 된 내용
X
