### PR TITLE
[PGS] 두 큐 합 같게 만들기 / level2 / 40분 / X

### DIFF
--- a/week7/PGS/두큐합같게만들기_한의정.java
+++ b/week7/PGS/두큐합같게만들기_한의정.java
@@ -1,2 +1,47 @@
-public class 두큐합같게만들기_한의정 {
+import java.util.*;
+
+class 두큐합같게만들기_한의정 {
+    public int solution(int[] queue1, int[] queue2) {
+        int answer = 0;
+
+        // 두 큐의 합 구하기
+        Deque<Integer> dq1 = new ArrayDeque<>();
+        Deque<Integer> dq2 = new ArrayDeque<>();
+
+        long sum1 = 0;
+        long sum2 = 0;
+
+        for(int i = 0 ; i < queue1.length ; i++) {
+            dq1.add(queue1[i]);
+            dq2.add(queue2[i]);
+
+            sum1 += queue1[i];
+            sum2 += queue2[i];
+        }
+
+        while(sum1 != sum2) {   // 두 덱의 합이 같기 전까지 반복
+            // 덱을 최대 3번까지 순회하며 합 맞출 수 있음 (제자리에 돌아오는 횟수가 덱 길이 * 3이므로)
+            if(answer >= queue1.length * 3) {
+                return -1;
+            }
+
+            // 두 큐 중 큰 쪽에서 작은 쪽으로 숫자 보내기
+            if(sum1 < sum2) {
+                int num = dq2.pollFirst();
+                dq1.addLast(num);
+                sum1 += num;
+                sum2 -= num;
+            }
+            else if(sum1 > sum2) {
+                int num = dq1.pollFirst();
+                dq2.addLast(num);
+                sum2 += num;
+                sum1 -= num;
+            }
+
+            answer++;
+        }
+
+        return answer;
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 10164 - [두 큐 합 같게 만들기](https://school.programmers.co.kr/learn/courses/30/lessons/118667)
<br/>

### 💡 풀이 방식
> 그리디
1. 큐 2개와, 각 큐의 합을 나타내는 변수 2개를 만든다.
2. 각 큐에 원소를 추가하고, 각 큐의 합을 구한다.
3. 두 큐의 합이 같아질 때까지 반복문을 수행한다.
   - 덱을 최대 3번까지 순회(= 덱 길이 * 3)하며 합을 맞춘다. 왜냐하면 큐가 제자리에 돌아오는 횟수가 덱 길이 * 3이므로
   - 두 큐 중 합이 큰 쪽에서 작은 쪽으로 숫자를 보내고, 횟수를 1 증가한다.
그래서 이렇게 풀었답니다!

<br/>

### 🤔 어려웠던 점
- 두 덱을 무한정 순회하면서 비교하는 게 아니라, 최대 덱 길이 *3번까지 순회할 수 있다는 것을 캐치하는 것

<br/>

### ❗ 새로 알게 된 내용
- 두 덱의 합을 매번 반복문으로 구할 생각을 했었는데, 그럴 필요 없이 변수에서 뺐다 더했다 하면 된다는 것
