### PR TITLE
[BOJ] 11053_가장긴증가하는부분수열 / 실버2 / 40분 / X

### DIFF
--- a/week7/BOJ_11053/가장긴증가하는부분수열.java
+++ b/week7/BOJ_11053/가장긴증가하는부분수열.java
@@ -1,0 +1,39 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        int[] a = new int[n];
+
+        int[] dp = new int[n];//dp[i]는 a[i]를 마지막으로 골랐을 때 최장 증가 부분 수열의 길이다.
+
+        st = new StringTokenizer(br.readLine());
+        for(int i = 0; i < n; i++){
+            a[i] = Integer.parseInt(st.nextToken());
+            dp[i] = 1; //모든수의 가장 긴 증가 부분수
+        }
+
+
+        int max = 1;//가장 긴 증가 부분수열의 길이 max
+        for(int i = 1; i < n; i++){
+            for(int j = 0; j < i; j++){
+                if(a[i] > a[j]){
+                    dp[i] = Math.max(dp[i],dp[j]+1);
+                }
+            }
+            max = Math.max(max,dp[i]);
+        }
+
+        for(int num: dp){
+            System.out.print(num+" ");
+        }
+        System.out.println(max);
+    }
+}


### PR DESCRIPTION
### 📖 문제
- 백준 11053 -  가장긴증가하는부분수열
<br/>

### 💡 풀이 방식

1. `dp[i]`는 a[i]를 마지막으로 골랐을 때 최장 증가 부분 수열의 길이다
2. 모든 수의 가장 긴 증가하는 부분수열의 길이의 최소값은 1이므로 dp[i] = 1로 초기화한다
3. 2중  for문을 사용해서 마지막으로 뽑은 수인 a[i]보다 전에 있는 숫자들인 a[j]들을 비교하면서 
만약 a[i] > a[j] 라면 `dp[i] = Math.max(dp[i],dp[j]+1)` 이라는 점화식을 세워 dp[i]를 구한다

<br/>

### 🤔 어려웠던 점
코드트리에서 간단하게 개념만 봤을때는 오 ~ 쉽네 ~ 했는데 시간이 지나니 어떻게 푸는지 기억이 나질 않았다. 
dp배열의 정의까진 했지만 점화식을 세우는것에서 막혔다. 

<br/>

### ❗ 새로 알게된 내용
이러한 문제를 '최장 증가 부분 수열(LIS)' 라고 부른다. 
