### PR TITLE
[PGS] 두 큐 합 같게 만들기 / 30분 / O

### DIFF
--- a/week7/PGS/두큐합같게만들기_강아현.py
+++ b/week7/PGS/두큐합같게만들기_강아현.py
@@ -1,0 +1,38 @@
+from collections import deque
+
+def solution(queue1, queue2):
+    answer = -1
+    q1sum = sum(queue1) # 초기 queue1의 합
+    q2sum = sum(queue2) # 초기 queue2의 합
+    
+    # queue1과 queue2가 같거나 두 리스트의 합이 같으면 연산 과정이 필요없다.
+    # 따라서 0을 리턴한다.
+    if queue1 == queue2 or q1sum == q2sum:
+        return 0
+
+    # queue1과 queue2의 합이 홀수인 경우 두 리스트의 합은 같아질 수 없다.
+    # 따라서 -1을 리턴한다.
+    if (q1sum + q2sum) % 2 != 0:
+        return -1
+    
+    # 
+    queue1 = deque(queue1)
+    queue2 = deque(queue2)
+    
+    cnt = 0
+    
+    for i in range(len(queue1)*3):
+        if q1sum == q2sum:
+            return cnt
+        elif q1sum > q2sum:
+            queue2.append(queue1.popleft())
+            q1sum -= queue2[-1]
+            q2sum += queue2[-1]
+            cnt += 1
+        elif q1sum < q2sum:
+            queue1.append(queue2.popleft())
+            q1sum += queue1[-1]
+            q2sum -= queue1[-1]
+            cnt += 1
+
+    return answer


### PR DESCRIPTION
### 📖 문제
- 프로그래머스 - 두 큐 합 같게 만들기
<br/>

### 💡 풀이 방식

> **큐의 합을 이용**
> - queue1과 queue2의 초기 합을 이용하기 위해 각각의 sum()을 구한다.

1. queue1 == queue2인 경우 혹은 sum()값이 같은 경우 : return 0
2. sum(queue1) + sum(queue2)가 홀수인 경우는 합을 같게 만들 수 없다.
3. for문이 반복하는 횟수는 큐의 전체 원소가 다른 큐로 이동했다가 다시 원래 큐로 돌아오는 횟수인 (큐 * 3)으로 한다.
4. sum()의 값이 더 큰 쪽 큐의 맨 왼쪽 값을 sum()이 작은 쪽 큐에 추가한다.
5. 이때, 이동하는 원소값으로 처음에 구해놓은 sum값에 더하거나 빼준다. (큰 sum() - 원소값) , (작은 sum() - 원소값)
6. 큐 원소가 이동할 때 cnt += 1
7. sum() 값이 같아지면 cnt를 리턴하고, sum()값이 같아지지 않는다면 -1을 리턴한다.

<br/>

### 🤔 어려웠던 점
시간 초과 문제를 해결하는 게 생각보다 어려웠다.

<br/>

### ❗ 새로 알게된 내용
x
