### PR TITLE
[BOJ] 15661_링크와 스타트 / 골드5 / 50분 / X

### DIFF
--- a/week9/BOJ_15661/링크와스타트_한의정.java
+++ b/week9/BOJ_15661/링크와스타트_한의정.java
@@ -1,2 +1,56 @@
+import java.util.*;
+import java.io.*;
+
 public class 링크와스타트_한의정 {
+    static int N;
+    static int[][] S;
+    static boolean[] chk;
+
+    static int min = Integer.MAX_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        S = new int[N][N];
+        chk = new boolean[N];
+
+        for(int i = 0 ; i < N ; i++) {
+            st = new StringTokenizer(br.readLine(), " ");
+            for(int j = 0 ; j < N ; j++) {
+                S[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        dfs(0);
+        System.out.println(min);
+    }
+
+    private static void dfs(int cnt) {
+        if(cnt == N) {  // [종료 조건] 마지막 원소까지 부분집합에 다 고려되었을 때
+            int start = 0;
+            int link = 0;
+
+            for(int i = 0 ; i < N ; i++) {
+                for(int j = i + 1 ; j < N ; j++) {
+                    if(chk[i] != chk[j])   continue;
+
+                    if(chk[i])  start += S[i][j] + S[j][i];
+                    else        link  += S[i][j] + S[j][i];
+                }
+            }
+
+            min = Math.min(min, Math.abs(start - link));
+            return;
+        }
+
+        // 해당 원소 선택
+        chk[cnt] = true;
+        dfs(cnt + 1);
+
+        // 해당 원소 비선택
+        chk[cnt] = false;
+        dfs(cnt + 1);
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 105661 - [링크와 스타트](https://www.acmicpc.net/problem/15661)
<br/>

### 💡 풀이 방식
부분 집합

- 부분 집합을 활용해 팀을 나눈다. ⇒ 방문 배열에서 선택된 사람은 스타트 팀에, 선택되지 않은 사람은 링크 팀에 넣는다.
- N명만큼 사람을 뽑았을 때, 스타트 팀과 링크 팀의 능력치를 계산하고 그 차이를 비교해 최솟값으로 갱신한다.

<br/>

### 🤔 어려웠던 점
- 36번째 줄 j를 0부터 시작하게 했더니 틀렸던 것 같다...
- 방문 배열에서 i번째 값과 j번째 값이 동일하면 같은 팀에 속해있다고 인식하고 pass 해야 하는데 이 부분을 캐치하지 못 했다..

<br/>

### ❗ 새로 알게 된 내용
**부분 집합** 개념
- boolean[] 배열을 통해 선택 여부만 확인하고 넘어가 배열의 원소가 true인 경우에만 결과 배열에 넣어도 된다. ([참고](https://velog.io/@albaneo0724/Algorithm%EC%88%9C%EC%97%B4-%EC%A1%B0%ED%95%A9-%EB%B6%80%EB%B6%84-%EC%A7%91%ED%95%A9))
