### PR TITLE
[BOJ] 파스칼 삼각형 / 실버4 / 30분 / O

### DIFF
--- a/week10/BOJ_15489/파스칼삼각형_한의정.java
+++ b/week10/BOJ_15489/파스칼삼각형_한의정.java
@@ -1,2 +1,38 @@
+import java.util.*;
+import java.io.*;
+
 public class 파스칼삼각형_한의정 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        int R = Integer.parseInt(st.nextToken());   // 행
+        int C = Integer.parseInt(st.nextToken());   // 열
+        int W = Integer.parseInt(st.nextToken());   // 정삼각형 변 길이
+
+        int[][] dp = new int[R + W][R + W];
+
+        for(int i = 1 ; i < dp.length ; i++) {
+            for(int j = 1 ; j <= i ; j++) {
+                if(i == j || j == 1)    // 행 번호=열 번호거나 1번째 열인 경우, 1로 채우기
+                    dp[i][j] = 1;
+                else    // 그 외 나머지 칸은 조합으로 채우기
+                    dp[i][j] = dp[i-1][j-1] + dp[i-1][j];
+            }
+        }
+
+        int sum = 0;
+        int tmp = 0;
+        for(int i = R ; i < R + W ; i++) {
+            tmp = i - R;    // j의 범위를 삼각형 모양으로 제한하기 위한 변수
+
+            for(int j = C ; j < C + W ; j++) {
+                if(R <= i && i < R + W && C <= j && j <= C + tmp) {
+                    sum += dp[i][j];
+                }
+            }
+        }
+
+        System.out.println(sum);
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 15489 - [파스칼 삼각형](https://www.acmicpc.net/problem/15489)
<br/>

### 💡 풀이 방식
> 시간 복잡도 :

1. dp 배열을 채운다.
   - 행 번호 = 열 번호인 칸 or 1번째 열에 있는 칸 ⇒ 1로 채운다.
   - 그 외 나머지 칸 ⇒ 현재 칸 (i,j) = 왼쪽 위 칸 (i-1, j-1) + 바로 위 칸 (i-1 ,j)
   ```java
   dp[i][j] = dp[i-1][j-1] + dp[i-1][j]
   ```
2. 점 (R,C) 부터 길이가 W인 정삼각형 범위의 합을 구한다.
  - int형 변수 `tmp` : 열 j의 범위를 (현재 행 i - 꼭짓점 R)한 길이만큼 설정해 삼각형 모양만큼만 값을 얻기 위한 변수

<br/>

### 🤔 어려웠던 점
삼각형 모양으로 제한하기 위해 j의 범위를 재설정해주는 부분에서 시간이 좀 오래 걸렸다..

<br/>

### ❗ 새로 알게 된 내용
역시나 풀고 보니 내가 또 어렵게 생각한 것이었는데 😂
합을 구하는 부분의 dp식은 아래와 같이 작성하면 된다.

```java
for(int i = 0 ; i < W ; i++) {
	for(int j = 0 ; j <= i ; j++) {
    	sum += dp[R + i][C + j];
    }
}
```
