### PR TITLE
[PGS] 양궁대회 / level2 / 40분 / X

### DIFF
--- a/week10/PGS_92342/양궁대회_한의정.java
+++ b/week10/PGS_92342/양궁대회_한의정.java
@@ -1,2 +1,63 @@
-public class 양궁대회_한의정 {
+import java.util.*;
+
+class 양궁대회_한의정 {
+    static int n;
+    static int[] info;
+
+    static int[] lion = {-1};           // 정답 배열
+    static int[] arrows = new int[11];  // 점수 차가 최대일 때 라이언이 쏜 화살 정보 저장용 배열
+
+    static int max = Integer.MIN_VALUE; // 최댓값
+
+    public int[] solution(int n, int[] info) {
+        this.n = n;
+        this.info = info;
+
+        dfs(0);
+
+        if(max == -1) { // 어피치가 이기는 경우
+            lion = new int[]{-1};
+        }
+        return lion;
+    }
+
+    // 라이언이 쏜 화살에 대한 조합 구하는 메서드
+    private static void dfs(int depth) {
+        if(depth == n) {
+            int diff = getScore();  // 점수 차 구하기
+
+            if(max <= diff) {   // 점수 차 최댓값 갱신
+                max = diff;
+                lion = arrows.clone();  // 화살 정보를 정답 배열로 복사
+            }
+            return;
+        }
+
+        for(int i = 0 ; i < info.length && arrows[i] <= info[i] ; i++) {    // 가지치기 조건 필수!! (안 하면 시간초과)
+            arrows[i]++;
+            dfs(depth + 1);
+            arrows[i]--;
+        }
+    }
+
+    // 점수 차 계산 메서드
+    private static int getScore() {
+        int apeach = 0;
+        int lion = 0;
+
+        for(int i = 0 ; i <= 10 ; i++) {
+            if(info[i] == 0 && arrows[i] == 0)  continue;   // 어피치, 라이언 둘 다 0 맞추면 무시
+
+            if(info[i] >= arrows[i])
+                apeach += (10 - i);
+            else
+                lion += (10 - i);
+        }
+
+        int diff = lion - apeach;
+
+        if(diff <= 0)
+            return -1;
+        return diff;
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 프로그래머스 92342 - [양궁대회](https://school.programmers.co.kr/learn/courses/30/lessons/92342)
<br/>

### 💡 풀이 방식
> DFS

1. 백트래킹으로 각 점수의 과녁에 화살 n개를 쏘는 조합을 구한다.
2. 백트래킹의 반복문은 아래 2가지 조건이 맞을 때만 돌도록 한다.
  - 과녁에 라이언이 맞춘 화살 수가 어피치가 맞춘 화살 수보다 작을 때 (arrows[i] <= inof[i])
  - 과녁 i에 어피치가 화살을 더 많이 쏜 경우에만 진행하도록 한다. (가지치기) 
3. 화살 n개를 모두 쐈을 때, 어피치와 라이언의 점수 차이를 구하고, 이 값이 최댓값보다 크다면 최댓값으로 변경하고, 이 때의 과녁 점수 배열 값을 정답 배열로 복사한다.

<br/>

### 🤔 어려웠던 점
- 가지치기 조건 생각해내기 ⇒ 조건을 반복문 안에 저렇게 넣지 않으면 시간초과가 발생하였다. (n=10이면 백트래킹에서 시간 초과가 발생하므로 사전에 미리 가지치기 하는 것)
- DFS인 것까지는 생각했는데 '_라이언이 가장 큰 점수 차이로 우승할 수 있는 방법이 여러 가지일 경우, 가장 낮은 점수를 더 많이 맞힌 경우를 return 해주세요_.' 이 조건을 어떻게 만족시켜야할지 고민이 되었다,,

<br/>

### ❗ 새로 알게 된 내용
- **가지치기 조건** : 과녁 i에 라이언이 임의의 점수에서 어피치에게 점수를 따내기 전까지만 반복문이 돌게 하는 것!! 이미 라이언이 어피치보다 과녁을 많이 맞춰서 이겼는데 더 많이 쏴봤자 의미가 없기 때문이다.
- '_라이언이 가장 큰 점수 차이로 우승할 수 있는 방법이 여러 가지일 경우, 가장 낮은 점수를 더 많이 맞힌 경우를 return 해주세요_.' ⇒ 백트래킹을 앞 원소부터 순차적으로 진행하면서 차례대로 요소가 늘어나므로, 마지막에 나오는 최댓값이 낮은 점수를 가장 많이 맞힌 경우가 된다고 한다... 