### PR TITLE
[BOJ] 9655_돌 게임 / 실버5 / 5분 / O

### DIFF
--- a/week12/BOJ_9655/돌게임_한의정.java
+++ b/week12/BOJ_9655/돌게임_한의정.java
@@ -1,2 +1,14 @@
+import java.io.*;
+
 public class 돌게임_한의정 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+
+        if(N % 2 == 1)
+            System.out.println("SK");
+        else
+            System.out.println("CY");
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 9655 - [돌 게임](https://www.acmicpc.net/problem/9655)
<br/>

### 💡 풀이 방식
돌 갯수 N이 홀수면 상근이가 이기고, 짝수면 창영이가 이긴다.
<br/>

### 🤔 어려웠던 점
X
<br/>

### ❗ 새로 알게 된 내용
문제의 의도는 DP인 것 같아 [dp를 활용한 풀이](https://propercoding.tistory.com/21)도 찾아보았다.
