### PR TITLE
[BOJ] 1463_1로 만들기 / 실버3 / 50분 / X

### DIFF
--- a/week12/BOJ_1463/일로만들기_한의정.java
+++ b/week12/BOJ_1463/일로만들기_한의정.java
@@ -1,2 +1,23 @@
+import java.io.*;
+
 public class 일로만들기_한의정 {
+    static int N;
+    static int[] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        dp = new int[N + 1];
+        dp[1] = 0;
+
+        for(int i = 2 ; i <= N ; i++) {
+            dp[i] = dp[i-1] + 1;    // -1 먼저 하기
+
+            if(i % 3 == 0)  dp[i] = Math.min(dp[i], dp[i/3] + 1);   // %3 연산
+            if(i % 2 == 0)  dp[i] = Math.min(dp[i], dp[i/2] + 1);   // %2 연산
+        }
+
+        System.out.println(dp[N]);
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 1463 - [1로 만들기](https://www.acmicpc.net/problem/1463)
<br/>

### 💡 풀이 방식
> DP
`dp[i] : 숫자 i를 1로 만들기 위한 최소 횟수`

1. 크기가 N+1인 배열을 생성하고, 초기값을 설정한다. (`dp[1] = 0`)
2. 2부터 N까지 점화식을 채운다.
   - 해당 칸을 먼저 이전 칸의 값+1 한 값으로 채운다. (`dp[i] = dp[i-1]+ 1`)
   - 현재 숫자가 3의 배수라면, `dp[3으로 나눈 몫] +1`과 현재 칸의 값 中 작은 값으로 현재 칸을 갱신한다.
   - 현재 숫자가 2의 배수라면, `dp[2로 나눈 몫] +1`과 현재 칸의 값 中 작은 값으로 현재 칸을 갱신한다.
3. dp[N]을 출력한다.

<br/>

### 🤔 어려웠던 점
점화식 찾기

<br/>

### ❗ 새로 알게 된 내용
X