### PR TITLE
[BOJ] 13335_트럭 / 실버1 / 40분 / X

### DIFF
--- a/week13/BOJ_13335/트럭_한의정.java
+++ b/week13/BOJ_13335/트럭_한의정.java
@@ -1,2 +1,44 @@
+import java.util.*;
+import java.io.*;
+
 public class 트럭_한의정 {
+    static int n,w,L;
+    static Queue<Integer> trucks = new LinkedList<>();  // 트럭 무게 저장용 큐
+    static Queue<Integer> bridge = new LinkedList<>();  // 다리 위에 있는 트럭 저장용 큐
+    static int time = 0;
+    static int sum = 0;    // 다리 위 트럭들의 무게의 합
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        n = Integer.parseInt(st.nextToken());
+        w = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine(), " ");
+        for(int i = 0 ; i < n ; i++) {
+            trucks.add(Integer.parseInt(st.nextToken()));
+        }
+
+        // 다리 길이만큼 0 저장해두기
+        for(int i = 0 ; i < w;  i++) bridge.add(0);
+
+        while(!bridge.isEmpty()) {  // 다리 위가 빌 때까지 반복문 수행
+            time++;
+            sum -= bridge.poll();
+
+            if(!trucks.isEmpty()) {
+                if(trucks.peek() + sum <= L) {  // 다리 위에 트럭 올리기
+                    sum += trucks.peek();
+                    bridge.add(trucks.poll());
+                }
+                else {  // 최대 무게 초과 시, 다리 위에 안 올림
+                    bridge.add(0);
+                }
+            }
+        }
+
+        System.out.println(time);
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 13335 - [트럭](https://www.acmicpc.net/problem/13335)
<br/>

### 💡 풀이 방식
> 큐

1. 총 두 개의 큐
   - 다리 위의 트럭들 저장용 큐 → 다리 길이 w만큼 0으로 채워두기
   - 오른쪽에 위치한 트럭들 저장용 큐
2. 다리 위가 빌 때까지 해당 과정을 반복한다.
   - 시간이 1초 소요되고
   - 다리의 맨 앞에 있는 트럭을 내린다. 이 때, 큐에서 뽑은 트럭의 무게를 다리 위의 트럭들의 무게의 합에서 뺀다.
   - 오른쪽에 트럭이 위치해 있다면, 해당 트럭의 무게와 현재 다리 위 트럭들의 무게의 합이 최대 하중보다 작거나 같을 때 해당 무게의 트럭을 다리 위로 올린다. 하지만 최대 하중보다 크다면, 다리 위에 아무 것도 안 올린다(=0 넣음)
 
<br/>

### 🤔 어려웠던 점
- 큐 사용할 아이디어를 생각하기까지 오래 걸린 듯
- 다리 위의 트럭들 저장할 큐를 길이가 w인 상태로 고정해둘 생각을 하지 못 했다.

<br/>

### ❗ 새로 알게 된 내용
- 다리 위의 트럭들 저장할 큐를 길이가 w로 고정해두고, 비워두려면 0으로 채우는 것