### PR TITLE
[BOJ] 1158_요세푸스 문제 / 실버4 / 35분 / O

### DIFF
--- a/week13/BOJ_1158/요세푸스문제_한의정.java
+++ b/week13/BOJ_1158/요세푸스문제_한의정.java
@@ -1,2 +1,38 @@
+import java.util.*;
+import java.io.*;
+
 public class 요세푸스문제_한의정 {
+    static int N,K;
+    static LinkedList<Integer> q = new LinkedList<>();
+    static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String[] str = br.readLine().split(" ");
+        N = Integer.parseInt(str[0]);
+        K = Integer.parseInt(str[1]);
+
+        if(N == 1) {
+            System.out.println("<1>");
+            return;
+        }
+
+        for(int i = 1 ; i <= N ; i++)   q.add(i);
+
+        int idx = K-1;
+        sb.append("<" + q.remove(idx) + ", ");
+
+        while(!q.isEmpty()) {
+            idx = (idx + K -1) % q.size();
+            int num = q.remove(idx);
+
+            sb.append(num);
+            if(q.size() != 0)
+                sb.append(", ");
+        }
+
+        sb.append(">");
+        System.out.println(sb.toString());
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 1158 [요세푸스 문제](https://www.acmicpc.net/problem/1158)
<br/>

### 💡 풀이 방식
> 큐 (LinkedList로 큐를 선언해 idx 위치에 있는 값 제거할 수 있게 함)

1. 큐에 1부터 N까지 숫자를 넣는다.
2. 맨 처음 뽑을 K-1번째 원소를 출력한다.
3. 이후 큐가 빌 때까지 위치 인덱스를 `(현재 위치 인덱스 + K -1) % 큐의 크기` 한 값으로 변경하고, 변경한 해당 위치의 인덱스를 제거하고, 출력한다.

<br/>

### 🤔 어려웠던 점
X

<br/>

### ❗ 새로 알게 된 내용
X
