### PR TITLE
[BOJ]16234_인구 이동 / 골드4 / 75분 / O

### DIFF
--- a/week14/BOJ_16234/인구이동_강아현.py
+++ b/week14/BOJ_16234/인구이동_강아현.py
@@ -1,0 +1,48 @@
+from collections import deque
+
+n, l, r = map(int,input().split())
+board = [list(map(int,input().split())) for _ in range(n)]
+answer = 0
+
+def bfs(x,y,visited,people, country_cnt):
+    q = deque()
+    q.append((x,y))
+    visited[x][y] = True
+    while q:
+        x, y = q.popleft()
+        now = board[x][y]
+        border[x][y] = 1
+        people += now
+        country_cnt += 1
+        for dx, dy in [(-1,0),(0,1),(1,0),(0,-1)]:
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < n and 0 <= ny < n and (l <= abs(now-board[nx][ny]) <= r) and not visited[nx][ny]:
+                q.append((nx,ny))
+                visited[nx][ny] = True
+    return people, country_cnt
+
+def update(board,border,new):
+    for i in range(n):
+        for j in range(n):
+            if border[i][j] == 1:
+                border[i][j] = str(1)
+                board[i][j] = new
+    return board
+
+while True:
+    visited = [[False]*n for _ in range(n)]
+    border = [[0]*n for _ in range(n)]
+    end = 1
+    for i in range(n):
+        for j in range(n):
+            if not visited[i][j]:
+                people, country_cnt = bfs(i,j,visited,0,0)
+                if people > 0 and country_cnt > 1:
+                    end = 0
+                    new = people // country_cnt
+                    board = update(board,border,new)
+                elif country_cnt <= 1: border[i][j], visited[i][j] = 0, False
+    if end == 1: break
+    else: answer += 1
+
+print(answer)


### PR DESCRIPTION
### 📖 문제
- 백준 16234 - 인구 이동
<br/>

### 💡 풀이 방식
> 시간 복잡도 : O(N^4)

> **bfs**
>
> - 현재 위치를 기준으로 상하좌우를 탐색하며 인구 차이가 L명 이상, R명 이하인 경우 q에 좌표를 추가한다.
>
> **update**
>
> - border는 연합을 이루고 있는 칸을 표시한 파라미터이다.
> - border == 1인 경우, 이 값을 문자열로 바꾸고 board의 값을 (연합의 인구수) / (연합을 이루고 있는 칸의 개수) 로 바꾼다.

1. visited, border를 매일 초기화한다.
2. end = 1로 초기화를 하며, 인구 이동이 있는 경우 이 값을 0으로 바꾼다. end == 1인 경우 인구 이동이 더이상 없는 경우이므로 while문을 탈출한다.


<br/>

### 🤔 어려웠던 점
x

<br/>

### ❗ 새로 알게된 내용
x
