### PR TITLE
[BOJ] 10711_모래성 / 골드2 / 60분 / X

### DIFF
--- a/week16/BOJ_10711/모래성_한의정.java
+++ b/week16/BOJ_10711/모래성_한의정.java
@@ -1,2 +1,64 @@
+import java.util.*;
+import java.io.*;
+
 public class 모래성_한의정 {
+    static int[] dr = {-1,1,0,0,-1,-1,1,1};
+    static int[] dc = {0,0,-1,1,-1,1,-1,1};
+
+    static int H,W;
+    static char[][] board;
+    static Queue<int[]> q = new ArrayDeque<>(); // 모래성이 "없는" 위치 저장 리스트
+    static int answer = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        H = Integer.parseInt(st.nextToken());
+        W = Integer.parseInt(st.nextToken());
+
+        board = new char[H][W];
+
+        for(int i = 0 ; i < H ; i++) {
+            String str = br.readLine();
+            for(int j = 0 ; j < W ; j++) {
+                board[i][j] = str.charAt(j);
+
+                if(board[i][j] == '.') {    // 모래성이 "없는" 위치 저장!!
+                    q.add(new int[] {i, j});
+                }
+            }
+        }
+
+        bfs();
+        System.out.println(answer - 1);
+    }
+
+    private static void bfs() {
+        while(!q.isEmpty()) {
+            int size = q.size();
+
+            for(int i = 0 ; i < size ; i++) {    // 큐 사이즈만큼 반복하게
+                int[] now = q.poll();
+
+                for(int d = 0 ; d < 8 ; d++) {  // 모래성이 "없는" 노드의 주변 8방향 탐색
+                    int nr = now[0] + dr[d];
+                    int nc = now[1] + dc[d];
+
+                    if(nr >= 0 && nr < H && nc >= 0 && nc < W) {
+                        if(board[nr][nc] != '.') {  // 모래성이라면, 튼튼함 1 깎기
+                            board[nr][nc]--;
+
+                            if(board[nr][nc] == '0') {  // 새로 모래성이 없어진 노드만 큐에 추가
+                                board[nr][nc] = '.';
+                                q.add(new int[] {nr, nc});
+                            }
+                        }
+                    }
+                }
+            }
+
+            answer++;
+        }
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 10711 - [모래성](https://www.acmicpc.net/problem/10711)
<br/>

### 💡 풀이 방식
> BFS (모래성이 **없는** 노드를 중심으로 탐색!)

1. 격자를 입력받을 때, 큐에 모래성이 **없는**(.) 위치를 저장한다.
2. BFS를 수행한다.
  - 큐 사이즈만큼 큐에서 모래성이 없는 노드를 뽑고, 주변 8방향을 탐색한다.
  - 8방향을 탐색했을 때, 인접한 칸이 모래성이라면 튼튼함을 -1한다.
  - 튼튼함을 하나 뺐을 때 새롭게 모래성이 없어진 노드라면, 큐에 추가해 탐색한다.


<br/>

### 🤔 어려웠던 점
- BFS에서 왜 큐 사이즈만큼 원소 뽑아 8방향 탐색을 하는 거지?를 고민했다.. 이유는 **모든 모래성을 한 번에 처리하기 위함**이라고 한다.
![image](https://github.com/bono039/algorithm-study/assets/67899934/09278070-440e-4791-b2f9-efab69b8234b)
- 모래성이 있는 위치를 큐에 저장해서 bfs를 할 생각을 했었다. (이런 풀이도 찾아보니 있긴 했다)

<br/>

### ❗ 새로 알게 된 내용
- bfs에서 큐 사이즈만큼 모래성이 없는 노드를 뽑아서 주변 8방향을 탐색하고 하는 것
- 새롭게 모래성이 없어진 노드만 큐에 추가해 마저 탐색하는 아이디어,,
