### PR TITLE
[BOJ] 2217_로프 / 실버4 / 30분 / X

### DIFF
--- a/week17/BOJ_2217/로프_한의정.java
+++ b/week17/BOJ_2217/로프_한의정.java
@@ -1,2 +1,23 @@
+import java.util.*;
+import java.io.*;
+
 public class 로프_한의정 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());    // 로프 수
+
+        int[] arr = new int[N];
+        for(int i = 0 ; i < N ; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+        Arrays.sort(arr);
+
+        int max = Integer.MIN_VALUE; // 로프들을 이용해 들어올릴 수 있는 물체의 최대 중량
+        for(int k = 0 ; k < N ; k++) {
+            max = Math.max(max, arr[k] * (N - k));  // 본인 뒤에 있는 원소들 모두 병렬로 연결하기
+        }
+
+        System.out.println(max);
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 2217 - [로프](https://www.acmicpc.net/problem/2217)
<br/>

### 💡 풀이 방식
> 그리디, 정렬

1. N개의 숫자들을 입력받고, 오름차순 정렬한다.
2. 정렬된 0~N-1개의 숫자를 사용하며, 본인 포함 뒷칸에 있는 원소들을 모두 사용해 병렬로 연결했을 때의 무게를 구한다. 이 값을 최댓값과 비교해 더 큰 값으로 갱신한다.
   > 최대 무게 w = min(병렬 연결된 로프의 중량) * 병렬 연결된 로프 수→ rope[k] * (N - k)

<br/>

> 예) [12, 20, 30, 33, 35]

n = 0 일때 12 * 5 = 60 (12 20 30 33 35)
n = 1 일때 20 * 4 = 80 (20 30 33 35)
n = 2 일때 30 * 3 = 90 (30 33 35)
n = 3 일때 33 * 2 = 40 (33 35)
n = 4 일때 35 * 1 = 40 (35)

이 중 90이 제일 큰 값이므로, 이 값을 정답으로 출력한다.


<br/>

### 🤔 어려웠던 점
(가장 작은 값 * 배열의 크기)를 해서 최대 무게 w를 구할 수 있겠단 생각은 했는데 그 다음 원소부터는 어떻게 할지 생각을 하지 못 했다.

<br/>

### ❗ 새로 알게 된 내용
w/k 식을 어디에 도대체 사용하는 거지? 했는데 `최대 무게(w) = 현재 위치의 로프에 걸리는 중량(arr[i]) * 현재부터 뒤까지 병렬 연결된 로프 수(N-k)` 이렇게 활용될 수 있군 했다.
