### PR TITLE
[BOJ] 13305_주유소 / 실버3 / 60분 / X

### DIFF
--- a/week17/BOJ_13305/주유소_한의정.java
+++ b/week17/BOJ_13305/주유소_한의정.java
@@ -1,2 +1,38 @@
+import java.util.*;
+import java.io.*;
+
 public class 주유소_한의정 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+
+        long[] dist = new long[N-1];    // 인접한 두 도시를 연결하는 도로의 길이
+        long[] gas = new long[N];       // 주유소 리터 당 가격
+
+        st = new StringTokenizer(br.readLine(), " ");
+        for(int i = 0 ; i < N-1 ; i++) {
+            dist[i] = Long.parseLong(st.nextToken());
+        }
+
+        st = new StringTokenizer(br.readLine(), " ");
+        for(int i = 0 ; i < N ; i++) {
+            gas[i] = Long.parseLong(st.nextToken());
+        }
+
+        long sum = 0;
+        long min = gas[0];  // 낮은 주유 가격
+
+        for(int i = 0 ; i < dist.length ; i++) {
+            // 주유 가격 비교해 더 낮은 주유 가격만큼 주유
+            if(gas[i] < min) {
+                min = gas[i];
+            }
+
+            sum += min * dist[i];
+        }
+
+        System.out.println(sum);
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 13305 - [주유소](https://www.acmicpc.net/problem/13305)
<br/>

### 💡 풀이 방식
> 그리디 (O(N))

1. 인접한 두 도시를 연결하는 도로의 길이를 입력받는다. (long형으로!)
2. 각 주유소의 리터 당 가격도 입력받는다. (얘도 long형으로)
3. 주유소 가격 배열을 반복문으로 돌면서 주유 가격을 비교하며 더 낮은 가격만큼 주유한다.
    ```
    long sum = 0;
    long min = gas[0];  // 낮은 주유 가격
    
    for(int i = 0 ; i < dist.length ; i++) {
        // 주유 가격 비교해 더 낮은 주유 가격만큼 주유
        if(gas[i] < min) {
            min = gas[i];
        }
    
        sum += min * dist[i];
    }
    ```

<br/>

### 🤔 어려웠던 점
- 주유 가격을 최소로 하기 위해 주유소와 그에 따른 거리를 구하는 경우의 수를 모두 다 구해 보고 비교해야 하나?라고 생각했다.
(예를 들어 주유소가 3개 있다고 할 때 [1번 주유소 1번만 방문하는 경우, 1번 주유소와 2번 주유소 방문하는 경우, 1-3번 주유소 다 방문하고 가는 경우] 이렇게...)

<br/>

### ❗ 새로 알게 된 내용
거리 값을 변경해서 사용할 생각을 하지 말자!
→ 그냥 주유 가격 배열을 돌면서 현재 주유 가격보다 낮을 때 주유 가격을 더 낮은 값으로 갱신하고, 그 가격으로 현재 도로의 길이만큼 이동시키면 되는 것이었다..
