### PR TITLE
[BOJ] 11000_강의실 배정 / 골드5 / 60분 / X

### DIFF
--- a/week17/BOJ_11000/강의실배정_한의정.java
+++ b/week17/BOJ_11000/강의실배정_한의정.java
@@ -1,2 +1,45 @@
+import java.util.*;
+import java.io.*;
+
 public class 강의실배정_한의정 {
+    static int N;
+    static int[][] arr;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+
+        arr = new int[N][2];
+        for(int i = 0 ; i < N ; i++) {
+            st = new StringTokenizer(br.readLine(), " ");
+            arr[i][0] = Integer.parseInt(st.nextToken());
+            arr[i][1] = Integer.parseInt(st.nextToken());
+        }
+
+        // 시작 시간이 같다면, 종료 시간 기준 오름차순 정렬하고
+        // 시작 시간이 다르다면, 시작 시간 기준 오름차순 정렬
+        Arrays.sort(arr, new Comparator<int[]>() {
+            @Override
+            public int compare(int[] o1, int[] o2) {
+                if(o1[0] == o2[0])  return o1[1] - o2[1];
+                return o1[0] - o2[0];
+            }
+        });
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>();  // 종료 시간 기준 오름차순 정렬하기 위한 우선순위 큐
+        pq.add(arr[0][1]);
+
+        for(int i = 1 ; i < N ; i++) {
+            // 가장 빨리 끝나는 강의의 종료 시간 vs 배정 안 된 강의의 시작 시간
+            if(pq.peek() <= arr[i][0])
+                pq.poll();
+
+            // 배정이 안 된 강의를 우선순위 큐에 넣음
+            pq.add(arr[i][1]);
+        }
+
+        System.out.println(pq.size());  // 우선순위 큐 크기 = 필요한 강의실 수
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 11000 - [강의실 배정](https://www.acmicpc.net/problem/11000)
<br/>

### 💡 풀이 방식
> 시간 복잡도 : O(N log N)

1. 시작 시간 s와 종료 시간 t를 저장할 2차원 배열을 만든다.
2. 2차원 배열을 정렬한다.
   - 시작 시간이 같다면, 종료 시간 기준 오름차순 정렬한다.
   - 시작 시간이 다르다면, 시작 시간 기준 오름차순 정렬한다.
3. 배열 내의 값을 종료 시간 기준 오름차순 정렬한다. 이를 위해 **_우선순위 큐_**를 사용한다.
4. 첫 번째 종료 시간 값을 넣고, 두 번째 원소부터 마지막 원소까지 아래 과정을 반복한다.
   - 가장 빨리 끝나는 강의의 종료 시간(pq.peek())과 배정 안 된 강의의 시작 시간 (arr[i][0])을 비교해 뒷 값이 더 크다면, 가장 빨리 끝나는 강의를 제거한다.
   - 배정되지 않은 강의의 종료 시간을 우선순위 큐에 넣는다.
5. 필요한 강의실 수 = 우선순위 큐에 남은 강의 수다.
<br/>

### 🤔 어려웠던 점
우선순위 큐를 사용해서 종료 시간 기준 오름차순 정렬을 계속하면서 값을 빼면서 사용할 생각을 하지 못 했다.

<br/>

### ❗ 새로 알게 된 내용
계속 종료 시간을 오름차순 정렬하기 위해 우선순위 큐에 종료 시간 값을 저장하고 활용하는 아이디어 (제거하고 추가하는 아이디어)
