### PR TITLE
[BOJ] 11054_가장 긴 바이토닉 부분 수열 / 골드4 / 40분 / X

### DIFF
--- a/week18/BOJ_11054/가장긴바이토닉부분수열_한의정.java
+++ b/week18/BOJ_11054/가장긴바이토닉부분수열_한의정.java
@@ -1,2 +1,60 @@
+import java.util.*;
+import java.io.*;
+
 public class 가장긴바이토닉부분수열_한의정 {
+    static int N;
+    static int[] arr, dp1, dp2;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        N = Integer.parseInt(br.readLine());
+
+        arr = new int[N + 1];
+        dp1 = new int[N + 1];
+        dp2 = new int[N + 1];
+
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        for(int i = 1 ; i <= N ; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+            dp1[i] = 1;
+            dp2[i] = 1;
+        }
+
+        LIS();  // 최장 증가 부분 수열 (L → R)
+        LDS();  // 최장 감소 부분 수열 (L ← R)
+
+        int max = 0;
+        for(int i = 1 ; i <= N ; i++) {
+            if(max < dp1[i] + dp2[i]) {
+                max = dp1[i] + dp2[i];
+            }
+        }
+
+        System.out.println(max - 1);    // 중복되는 값 1개 빼주기
+    }
+
+    // 최장 증가 부분 수열 (L → R)
+    private static void LIS() {
+        for(int i = 1 ; i <= N ; i++) {
+            for(int j = 1 ; j < i ; j++) {  // 비교 대상 : 1 ~ i-1번 원소
+                if(arr[i] <= arr[j])    continue;
+
+                if(dp1[i] < dp1[j] + 1)
+                    dp1[i] = dp1[j] + 1;
+            }
+        }
+    }
+
+    // 최장 감소 부분 수열 (L ← R)
+    private static void LDS() {
+        for(int i = N ; i >= 1; i--) {  // 맨 뒤에서부터 시작
+            for(int j = N ; j > i ; j--) {  // 맨 뒤에서 i 이전 원소들 탐색
+                if(arr[i] <= arr[j])    continue;
+
+                if(dp2[i] < dp2[j] + 1)
+                    dp2[i] = dp2[j] + 1;
+            }
+        }
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 11054 - [가장 긴 바이토닉 부분 수열](https://www.acmicpc.net/problem/11054)
<br/>

### 💡 풀이 방식
> DP → 시간 복잡도 : O(N)

최장 증가 부분 수열의 최댓값과 최장 감소 부분 수열의 최댓값을 더한 후, 중복되는 값 1개를 뺀 값을 정답으로 한다.


1. 최장 증가 부분 수열 구하기
   - 왼쪽(1)에서 오른쪽(N)으로 진행하며 최장 증가 부분 수열을 구한다.
    ```
    private static void LIS() {
        for(int i = 1 ; i <= N ; i++) {
            for(int j = 1 ; j < i ; j++) {  // 비교 대상 : 1 ~ i-1번 원소
                if(arr[i] <= arr[j])    continue;
    
                if(dp1[i] < dp1[j] + 1)
                    dp1[i] = dp1[j] + 1;
            }
        }
    }
    ```

2. 최장 감소 부분 수열 구하기
   - 최장 증가 부분 수열을 오른쪽(N)에서 왼쪽(1)으로 진행하면서 구하면 된다.
    ```
    private static void LDS() {
        for(int i = N ; i >= 1; i--) {  // 맨 뒤에서부터 시작
            for(int j = N ; j > i ; j--) {  // 맨 뒤에서 i 이전 원소들 탐색
                if(arr[i] <= arr[j])    continue;

                if(dp2[i] < dp2[j] + 1)
                    dp2[i] = dp2[j] + 1;
            }
        }
    }
    ```

<br/>

### 🤔 어려웠던 점
- 최장 감소 부분 수열 인덱스를 적다가 헷갈렸다,,

<br/>

### ❗ 새로 알게 된 내용
- dp를 양 옆에서 진행해서 두 값을 둘 다 사용할 줄 몰랐다,,
- 두 방향으로 dp를 진행했을 때 원소 1개는 중복되니까 빼는 아이디어
