### PR TITLE
[BOJ] 1389_케빈 베이컨의 6단계 법칙 / 실버1 / 20분 / O

### DIFF
--- a/week21/BOJ_1389/케빈베이컨의6단계법칙_한의정.java
+++ b/week21/BOJ_1389/케빈베이컨의6단계법칙_한의정.java
@@ -1,2 +1,58 @@
+import java.util.*;
+import java.io.*;
+
 public class 케빈베이컨의6단계법칙_한의정 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        int N = Integer.parseInt(st.nextToken());   // 유저 수
+        int M = Integer.parseInt(st.nextToken());   // 친구 관계 수
+
+        int[][] dp = new int[N+1][N+1];
+
+        while(M --> 0) {
+            st = new StringTokenizer(br.readLine(), " ");
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            // 양방향
+            dp[a][b] = 1;
+            dp[b][a] = 1;
+        }
+
+        // [플로이드-워셜] dp 배열 채우기
+        for(int k = 1 ; k <= N ; k++) { // 경유지
+            for(int i = 1 ; i <= N ; i++) { // 출발지
+                for(int j = 1 ; j <= N ; j++) { // 도착지
+                    if(i==j || j==k || k==i)    continue;
+
+                    if(dp[i][k] != 0 && dp[k][j] != 0) {    // 출발지와 도착지를 연결하는 경유지가 있으면
+                        if(dp[i][j] == 0)   // 친구 관계가 없으면 값 그대로 넣기
+                            dp[i][j] = dp[i][k] + dp[k][j];
+                        else    // 이미 친구 관계가 있다면, 더 작은 케빈 베이컨 수 넣기
+                            dp[i][j] = Math.min(dp[i][j], dp[i][k] + dp[k][j]);
+                    }
+                }
+            }
+        }
+
+        int min = 5000; // 최소 케빈 베이컨 수
+        int answer = 0; // 번호가 가장 작은 사람
+
+        for(int i = 1 ; i <= N ; i++) {
+            int tmp = 0;
+
+            for(int j = 1 ; j <= N ; j++) {
+                if(i != j)
+                    tmp += dp[i][j];
+            }
+
+            if(tmp < min) {
+                min = tmp;
+                answer = i;
+            }
+        }
+        System.out.println(answer);
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 1389 - [케빈 베이컨의 6단계 법칙](https://www.acmicpc.net/problem/1389)
<br/>

### 💡 풀이 방식
> 플로이드-워셜 ⇒ 시간 복잡도 : O(N^3)


<br/>
2차원 int형 배열에 i와 j가 몇 단계를 거쳐 친구가 될 수 있는지 입력한다.

1. M개의 입력을 받으며 a와 b가 1단계 친구임을 양방향으로 입력한다.
2. 친구 a와 b가 친구고(`dp[a][b] != 0`), b와 c가 친구라면(`dp[b][c] != 0`), a와 c도 친구다.
   - 만약 a와 c가 친구 관계가 없으면 (`dp[a][c] == 0`), a와 b의 케빈 베이컨 수와 b와 c의 케빈 베이컨 수를 더한다. (`dp[a][c] = dp[a][b] + dp[b][c]`)
   - 이미 a와 c가 친구 관계라면, 기존 케빈 베이컨 수와 현재 케빈 베이컨 수 중 더 작은 케빈 베이컨 수를 넣는다. (dp[a][c] = Math.min(dp[a][c], dp[a][b] + dp[b][c]);)
3. 1부터 N번 사람까지 케빈 베이컨 수의 합을 구하고, 이 합이 가장 작은 사람의 번호를 출력한다.

<br/>

### 🤔 어려웠던 점
X

<br/>

### ❗ 새로 알게 된 내용
X
