### PR TITLE
[BOJ]2217_로프 / 실버4 / 10분 / O

### DIFF
--- a/week17/BOJ_2217/로프_강아현.py
+++ b/week17/BOJ_2217/로프_강아현.py
@@ -1,0 +1,10 @@
+n = int(input())
+ropes = [int(input()) for _ in range(n)]
+ropes.sort(reverse=True)
+
+ans, cnt = 0, 0
+for rope in ropes:
+    cnt += 1
+    if ans < rope * cnt:
+        ans = rope * cnt
+print(ans)


### PR DESCRIPTION
### 📖 문제
- 백준 2217 - 로프
<br/>

### 💡 풀이 방식

> `k개의 로프를 사용하여 중량이 w인 물체를 들어올릴 때, 각각의 로프에는 모두 고르게 w/k 만큼의 중량이 걸리게 된다.`
>
>> 예시
>> - 로프의 최대 중량이 각각 100, 50, 10인 로프가 있다고 한다.
>> - 100인 로프만 사용
>>  - 최대 중량 : 100 * 1 = 100
>> - 100, 50인 로프 사용
>>  - 최대 중량 : 50인 로프는 최대 중량 100까지 버틸 수 있다.
>> - 100, 10인 로프 사용
>>  - 최대 중량 : 10인 로프는 최대 중량 20까지 버틸 수 있다.
>> - 100, 50, 10인 로프 사용
>>  - 최대 중량 : 10인 로프는 최대 중량 30까지 버틸 수 있다.
>
> 위의 예시를 통해 아래와 같이 풀 수 있다. (Greedy)
> 1. 로프 최대 중량을 내림차순으로 정렬한다.
> 2. 내림차순으로 정렬된 로프의 중량을 순차적으로 하나씩 방문하며 `(중량 * cnt(병렬로 연결된 로프의 개수))`의 값을 구한다.
> 3. 2에서 구한 값이 현재 `ans` 값보다 큰 경우 `ans` 값을 업데이트한다.

<br/>

### 🤔 어려웠던 점
x

<br/>

### ❗ 새로 알게된 내용
x
