### PR TITLE
[BOJ] 17070_파이프 옮기기 1 / 골드5 / 50분 / X

### DIFF
--- a/week22/BOJ_17070/파이프옮기기1_한의정.java
+++ b/week22/BOJ_17070/파이프옮기기1_한의정.java
@@ -1,2 +1,60 @@
+import java.util.*;
+import java.io.*;
+
 public class 파이프옮기기1_한의정 {
+    static int N;
+    static int[][] map;
+    static int answer = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        map = new int[N][N];
+
+        for(int i = 0 ; i < N ; i++) {
+            st = new StringTokenizer(br.readLine(), " ");
+            for(int j = 0 ; j < N ; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        dfs(0,1,0);
+        System.out.println(answer);
+    }
+
+    private static void dfs(int x, int y, int dir) {
+        if(x == N-1 && y == N-1) {  // [종료 조건] 목적지 도착 시
+            answer++;
+            return;
+        }
+
+        // 1. 가로 방향인 경우, → ↘  이동 가능
+        if(dir == 0) {
+            if(inRange(x, y+1) && map[x][y+1] == 0)  // → 이동
+                dfs(x, y+1, 0);
+        }
+        // 2. 세로 방향인 경우, ↓ ↘ 이동 가능
+        else if(dir == 1) {
+            if(inRange(x+1, y) && map[x+1][y] == 0) // ↓ 이동
+                dfs(x+1, y, 1);
+        }
+        // 3. 대각선 방향인 경우, → ↓ ↘ 이동 가능
+        else if(dir == 2) {
+            if(inRange(x, y+1) && map[x][y+1] == 0) // → 이동
+                dfs(x, y+1, 0);
+
+            if(inRange(x+1, y) && map[x+1][y] == 0) // ↓ 이동
+                dfs(x+1, y, 1);
+        }
+
+        // [공통] 어떤 방향이든,  ↘  이동
+        if(inRange(x+1, y+1) && map[x][y+1] == 0 && map[x+1][y] == 0 && map[x+1][y+1] == 0)
+            dfs(x+1, y+1, 2);
+    }
+
+    private static boolean inRange(int x, int y) {
+        return 0 <= x && x < N && 0 <= y && y < N;
+    }
 }


### PR DESCRIPTION
### 📖 문제
- 백준 17070 - [파이프 옮기기 1](https://www.acmicpc.net/problem/17070)
<br/>

### 💡 풀이 방식
> DFS (시간 복잡도 : O(3^(N^2)))

(0,1)부터 (N-1, N-1)까지 도달하는 DFS를 수행한다.
- 종료 조건 : 목적지 (N-1. N-1)을 도달한 경우, 정답+1하고 종료
- **현재 파이프의 방향에 따라** 파이프를 옮긴다. (재귀 호출 : 함수 파라미터 - 행,열,파이프 방향 나타내는 번호)
    - 가로 방향(0)인 경우, 가로와 대각선 방향으로 이동 가능하다.
    - 세로 방향(1)인 경우, 세로와 대각선 방향으로 이동 가능하다.
    - 대각선 방향(2)인 경우, 가로,세로,대각선 방향으로 이동 가능하다.

<br/>

### 🤔 어려웠던 점
- 재귀를 쓸 생각은 했는데 재귀함수에 파라미터로 행,열 위치를 들고 다니면서 회전시키고 활용할 생각을 하지 못 했다.

<br/>

### ❗ 새로 알게 된 내용
- 이런 문제에서 DFS를 쓸 생각을 한다는 것..
- [DP를 이용한 풀이](https://codeung.tistory.com/248)도 있다!
