### PR TITLE
[BOJ]11727_2xn 타일링 2 / 실버3 / 30분 / O

### DIFF
--- a/week18/BOJ_11727/타일링2_강아현.py
+++ b/week18/BOJ_11727/타일링2_강아현.py
@@ -1,0 +1,17 @@
+import math
+
+n = int(input())
+ans = 0
+
+for i in range(n, -1, -1):
+    y = n - i
+    if y % 2 == 0:
+        cnt = y // 2
+        if i != 0:
+            tmp = math.comb(i + cnt, cnt)
+            ans += tmp * (2 ** cnt)
+        else:
+            ans += 2 ** cnt
+    ans %= 10007
+
+print(ans)


### PR DESCRIPTION
### 📖 문제
- 백준 11727 - 2xn 타일링 2
<br/>

### 💡 풀이 방식
> 시간 복잡도 : O(n)

<br>

> 2x1 인 타일을 기준으로 타일 개수 경우의 수를 계산했다.
>
> - 1x2 타일이 사용되기 위해서는 반드시 2개를 사용하여 2x2로 만들어야 한다.
> - 1x2와 2x2는 2x2로 통일하여 개수를 구한 후, 개수에 x2를 해주면 모든 경우의 수를 구할 수 있다.
>
> <br>
>
> - 2x2와 2x1 타일이 모두 쓰이는 경우, `math.comb`를 사용해서 타일 배치의 모든 경우의 수를 구할 수 있다.
> - 위에서 math.comb로 구한 경우의 수에 `2 ** cnt`를 곱하면 1x2, 2x2 두 종류를 사용하는 경우까지 고려한다.
> - i == 0인 경우에는 2x2사이즈만 쓰이므로 `2 ** cnt`가 모든 경우의 수가 된다.


<br/>

### 🤔 어려웠던 점

- dp로 푸는 방식
```python
  n = int(input())
  dp = [0] * 1001

  # 초기값 지정
  dp[0] = 1
  dp[1] = 1

  # 점화식에 따른 경우의 수 계산
  for i in range(2, n+1):
      dp[i] = dp[i-1] + 2 * dp[i-2]

  print(dp[n]%10007)
```

<br/>

### ❗ 새로 알게된 내용
x
