### PR TITLE
[BOJ]15990_1,2,3 더하기 5 / 실버2 / 60분 / O

### DIFF
--- a/week18/BOJ_15990/더하기5_강아현.py
+++ b/week18/BOJ_15990/더하기5_강아현.py
@@ -1,0 +1,20 @@
+def dp_table(n):
+    MOD = 1000000009
+
+    dp = [[0, 0, 0] for _ in range(n + 1)]
+    dp[1] = [1, 0, 0]
+    dp[2] = [0, 1, 0]
+    dp[3] = [1, 1, 1]
+
+    for i in range(4, n + 1):
+        dp[i][0] = (dp[i - 1][1] + dp[i - 1][2]) % MOD
+        dp[i][1] = (dp[i - 2][0] + dp[i - 2][2]) % MOD
+        dp[i][2] = (dp[i - 3][0] + dp[i - 3][1]) % MOD
+
+    return dp
+
+t = int(input())
+dp = dp_table(100000)
+for _ in range(t):
+    n = int(input())
+    print(sum(dp[n]) % 1000000009)


### PR DESCRIPTION
### 📖 문제
- 백준 15990 - 1,2,3 더하기 5
<br/>

### 💡 풀이 방식
> 시간 복잡도 : O(n+t)

1. 함수 `find_ways(n)`은 1부터 n까지의 정수를 각각 1, 2, 3의 합으로 나타내는 방법의 수를 저장하는 2차원 리스트를 반환한다. `dp[i][j]`는 i를 마지막에 j를 사용하여 만드는 경우의 수를 의미한다.
2. n이 1, 2, 3인 경우에 대한 초기값을 설정한다.
3. `dp[i][0]` : 마지막에 1이 오는 경우, 이전 숫자는 2 또는 3이어야 한다.
4. `dp[i][1]` : 마지막에 2가 오는 경우, 이전 숫자는 1 또는 3이어야 한다.
5. `dp[i][2]` : 마지막에 3이 오는 경우, 이전 숫자는 1 또는 2이어야 한다.
6. `find_ways(100000)`로 **dp 테이블을 먼저 생성한다.**

<br/>

### 🤔 어려웠던 점

하..... 메모리 초과와 시간초과가 계속 나와서 해결이 안됐는데 n값을 받을 때마다 dp 계산을 해서 그런거였다.
미리 dp를 만들어놓고 입력되는 n 값에 따라서 dp에서 구하면 되는 거였다.
이 생각을 못해서 시간 이렇게 걸릴 일은 다시 일어나지 않길..

<br/>

### ❗ 새로 알게된 내용
x
