### PR TITLE
[BOJ]11054_가장 긴 바이토닉 부분 수열 / 골드4 / 30분 / O

### DIFF
--- a/week18/BOJ_11054/가장긴바이토닉부분수열_강아현.py
+++ b/week18/BOJ_11054/가장긴바이토닉부분수열_강아현.py
@@ -1,0 +1,13 @@
+n = int(input())
+a = list(map(int,input().split()))
+dp = [1] * (n+1)
+for i in range(n):
+    for j in range(i):
+        if a[i] > a[j]:
+            dp[i] = max(dp[i], dp[j] + 1)
+            
+for i in range(n):
+    for j in range(i,n):
+        if a[i] > a[j]:
+            dp[j] = max(dp[j], dp[i] + 1)
+print(max(dp))


### PR DESCRIPTION
### 📖 문제
- 백준 11054 - 가장 긴 바이토닉 부분 수열
<br/>

### 💡 풀이 방식

> **DP**
1. dp 의 모든 요소를 1로 설정하는 이유는 각 요소 자체만으로도 길이가 1인 부분 수열이 되기 때문이다.
2. 가장 긴 증가하는 부분 수열(LIS) 계산을 한다.
  - `a[i] > a[j]` 조건을 만족하는 경우, `dp[i]`를 갱신한다.
  - `a[j]` 까지의 LIS에 `a[i]`를 추가하여 더 긴 LIS를 만들 수 있는 경우를 의미한다.
  - `dp[i]`를 `dp[j] + 1`과 비교하여 더 큰 값으로 갱신한다.
3. 가장 긴 감소하는 부분 수열(LDS) 계산을 한다.
  - `a[i] > a[j]` 조건을 만족하는 경우, `dp[j]`를 갱신한다.
  - `a[i]` 까지의 LDS에 `a[j]`를 추가하여 더 긴 LDS를 만들 수 있는 경우를 의미한다.
  - `dp[j]`를 `dp[i] + 1`과 비교하여 더 큰 값으로 갱신한다.
4. 결과적으로 dp는 LIS와 LDS가 결합된 결과값이 나오게 된다.
5. dp의 최대값을 출력한다.

<br/>

### 🤔 어려웠던 점
x

<br/>

### ❗ 새로 알게된 내용
x
