### PR TITLE
[BOJ]11066_파일 합치기 / 골드3 / 60분 / X

### DIFF
--- a/week18/BOJ_11066/파일합치기_강아현.py
+++ b/week18/BOJ_11066/파일합치기_강아현.py
@@ -1,0 +1,13 @@
+t = int(input())
+for _ in range(t):
+    k = int(input())
+    papers = [0] + list(map(int,input().split()))
+    l = [0] * (k+1)
+    for i in range(1,k+1):
+        l[i] = l[i-1] + papers[i]
+    dp = [[0]*(k+1) for _ in range(k+1)]
+
+    for i in range(2,k+1):
+        for j in range(1,k+2-i):
+            dp[j][j+i-1] = min([dp[j][j+d] + dp[j+d+1][j+i-1] for d in range(i-1)]) +(l[j+i-1] - l[j-1])
+    print(dp[1][k])


### PR DESCRIPTION
### 📖 문제
- 백준 11066 - 파일 합치기
<br/>

### 💡 풀이 방식

> **DP**
>
> `l`
> - `l`은 부분합을 저장하는 리스트로 `l[i]`는 papers 리스트의 1 번부터 i 번 파일까지의 합이다.
>
> `dp`
> - `dp[i][j]`는 i 번 파일부터 j 번 파일까지를 합치는 데 드는 최소 비용을 저장한다.
>

<br/>

```python
  for i in range(2, k+1):
    for j in range(1, k+2-i):
      dp[j][j+i-1] = min([dp[j][j+k] + dp[j+k+1][j+i-1] for k in range(i-1)]) + (l[j+i-1] - l[j-1])

```

> 첫 번째 for문
>
> - `i` : 파일 묶음의 길이
> - i 는 최소 2에서 최대 k까지 증가한다.

> 두 번째 for문
>
> - `j` : 파일 묶음의 시작 인덱스
> - j 는 1부터 시작하여 k+1-i 까지 증가한다.<br> -> 묶음의 길이가 i 일때, 시작 인덱스 j 가 커져서 묶음이 범위를 벗어나는 것을 방지한다.

<br/>

> DP 갱신
>
> - `dp[j][j+i-1]` 는 j 번 파일부터 j+i-1 번 파일까지 합치는 데 드는 최소 비용을 저장
>> `[dp[j][j+d] + dp[j+d+1][j+i-1] for d in range(i-1)]`
>> 
>> - j 번 파일부터 j+i-1 번 파일까지의 모든 가능한 분할 지점을 고려하여, 각 분할 지점에서 두 부분을 합치는 비용의 합 계산
>>
>> `l[j + i - 1] - l[j - 1]`
>>
>> - j 번 파일부터 j+i-1 번 파일까지의 크기의 합으로, 이 구간을 합치는 데 드는 비용

<br/>

### 🤔 어려웠던 점

길이를 같이 가져가는 dp는 어려운 것 같다. 방법 자체를 생각해내지 못했다.

<br/>

### ❗ 새로 알게된 내용
x
